### PR TITLE
Set min required version of php to 7.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
     "name": "softwarethings/form-carter",
     "description": "Simple library to easily send emails from your contact forms",
     "require": {
+        "php": "^7.1",
         "swiftmailer/swiftmailer": "^6.0"
     }
 }


### PR DESCRIPTION
Program won't work on php 7.0 or lower (e.g. no void return type).